### PR TITLE
Added a delete function to clear the qmckl_context instance.

### DIFF
--- a/src/qmckl_context.org
+++ b/src/qmckl_context.org
@@ -90,18 +90,18 @@ qmckl_context qmckl_context_copy(qmckl_context context) {
 }
    #+END_SRC
 
-** =qmckl_context_delete=
+** =qmckl_context_destroy=
 
-   To delete a new context, use =qmckl_context_delete()=. If the deletion
+   To delete a new context, use =qmckl_context_destroy()=. If the deletion
    failed, the function returns =0=. On success, the function returns =1=
    implying that the context has been freed.
 
    #+BEGIN_SRC C :tangle qmckl_context.h
-qmckl_context qmckl_context_delete(qmckl_context context);
+qmckl_context qmckl_context_destroy(qmckl_context context);
    #+END_SRC
 
    #+BEGIN_SRC C :tangle qmckl_context.c
-qmckl_context qmckl_context_delete(qmckl_context context) {
+qmckl_context qmckl_context_destroy(qmckl_context context) {
 
   if (context == NULL) {
     return (qmckl_context) 0;

--- a/src/qmckl_context.org
+++ b/src/qmckl_context.org
@@ -90,6 +90,27 @@ qmckl_context qmckl_context_copy(qmckl_context context) {
 }
    #+END_SRC
 
+** =qmckl_context_delete=
+
+   To delete a new context, use =qmckl_context_delete()=. If the deletion
+   failed, the function returns =0=. On success, the function returns =1=
+   implying that the context has been freed.
+
+   #+BEGIN_SRC C :tangle qmckl_context.h
+qmckl_context qmckl_context_delete(qmckl_context context);
+   #+END_SRC
+
+   #+BEGIN_SRC C :tangle qmckl_context.c
+qmckl_context qmckl_context_delete(qmckl_context context) {
+
+  if (context == NULL) {
+    return (qmckl_context) 0;
+  }
+
+  free(context);
+  return (qmckl_context) 1;
+}
+   #+END_SRC
 
 * Precision
 


### PR DESCRIPTION
Perhaps we want to organize garbage collection differently !? I thought it's a nice first commit to add a basic delete function to motivate the ways in which instances can be deleted. Obviously this is only a proposal to learn from. Note that no information is being sent (other than the fact that free has been called) about the contents of the _context_ instance after the call to the function.