### PR TITLE
Use const qualifiers with qmckl_context

### DIFF
--- a/src/qmckl_context.org
+++ b/src/qmckl_context.org
@@ -1,6 +1,6 @@
 # -*- mode: org -*-
 
-#+TITLE: Context 
+#+TITLE: Context
 
 This file is written in C because it is more natural to express the context in
 C than in Fortran.
@@ -17,7 +17,7 @@ C than in Fortran.
   is stored in the following data structure, which can't be seen
   outside of the library.
 
-  
+
   #+BEGIN_SRC C :tangle qmckl_context.h
 #define QMCKL_DEFAULT_PRECISION 53
 #define QMCKL_DEFAULT_RANGE     2

--- a/src/qmckl_context.org
+++ b/src/qmckl_context.org
@@ -66,11 +66,11 @@ qmckl_context qmckl_context_create() {
 ** =qmckl_context_copy=
 
    #+BEGIN_SRC C :tangle qmckl_context.h
-qmckl_context qmckl_context_copy(qmckl_context context);
+qmckl_context qmckl_context_copy(const qmckl_context context);
    #+END_SRC
 
    #+BEGIN_SRC C :tangle qmckl_context.c
-qmckl_context qmckl_context_copy(qmckl_context context) {
+qmckl_context qmckl_context_copy(const qmckl_context context) {
 
   qmckl_context_struct* old_context;
   qmckl_context_struct* new_context;
@@ -102,11 +102,11 @@ qmckl_context qmckl_context_copy(qmckl_context context) {
 ** =qmckl_context_set_precision=
 
    #+BEGIN_SRC C :tangle qmckl_context.h
-qmckl_context qmckl_context_set_precision(qmckl_context context, int precision);
+qmckl_context qmckl_context_set_precision(const qmckl_context context, int precision);
    #+END_SRC
 
    #+BEGIN_SRC C :tangle qmckl_context.c
-qmckl_context qmckl_context_set_precision(qmckl_context context, int precision) {
+qmckl_context qmckl_context_set_precision(const qmckl_context context, int precision) {
   qmckl_context_struct* ctx;
 
   if (precision <  2) return (qmckl_context) 0;
@@ -120,11 +120,11 @@ qmckl_context qmckl_context_set_precision(qmckl_context context, int precision) 
 
 ** =qmckl_context_set_range=
    #+BEGIN_SRC C :tangle qmckl_context.h
-qmckl_context qmckl_context_set_range(qmckl_context context, int range);
+qmckl_context qmckl_context_set_range(const qmckl_context context, int range);
    #+END_SRC
 
    #+BEGIN_SRC C :tangle qmckl_context.c
-qmckl_context qmckl_context_set_range(qmckl_context context, int range) {
+qmckl_context qmckl_context_set_range(const qmckl_context context, int range) {
   qmckl_context_struct* ctx;
 
   if (range <  2) return (qmckl_context) 0;
@@ -141,11 +141,11 @@ qmckl_context qmckl_context_set_range(qmckl_context context, int range) {
 ** =qmckl_context_get_precision=
 
    #+BEGIN_SRC C :tangle qmckl_context.h
-int qmckl_context_get_precision(qmckl_context context);
+int qmckl_context_get_precision(const qmckl_context context);
    #+END_SRC
 
    #+BEGIN_SRC C :tangle qmckl_context.c
-int qmckl_context_get_precision(qmckl_context context) {
+int qmckl_context_get_precision(const qmckl_context context) {
   qmckl_context_struct* ctx;
   ctx = (qmckl_context_struct*) context;
   return ctx->precision;
@@ -155,11 +155,11 @@ int qmckl_context_get_precision(qmckl_context context) {
 ** =qmckl_context_get_range=
 
    #+BEGIN_SRC C :tangle qmckl_context.h
-int qmckl_context_get_range(qmckl_context context);
+int qmckl_context_get_range(const qmckl_context context);
    #+END_SRC
 
    #+BEGIN_SRC C :tangle qmckl_context.c
-int qmckl_context_get_range(qmckl_context context) {
+int qmckl_context_get_range(const qmckl_context context) {
   qmckl_context_struct* ctx;
   ctx = (qmckl_context_struct*) context;
   return ctx->range;


### PR DESCRIPTION
Hi,

From the initial design of `qmckl_context` it seems we are making it immutable. I see the advantages of this to avoid errors, but do also worry about performance issues. For example, setting range and precision will require two setters calls and thus two structures deep copies. 

A first question is thus: should we remove the copy from setters and let the user explicitly copy the context, this would allow to chain multiple setters without unneeded copies ?

A second point, in case we decide to keep "pure" setters, it would be good to add `const` qualifiers to make this explicit and verifiable.
