### PR TITLE
Fix Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,9 +4,12 @@ CFLAGS=
 FC=gfortran
 FFLAGS=
 
-SOURCE_FILES=$(wildcard *.org)
+ORG_SOURCE_FILES=qmckl_context.org
+OBJECT_FILES=$(patsubst %.org,%.o,$(ORG_SOURCE_FILES))
 
 .PHONY: clean
+
+all: $(OBJECT_FILES)
 
 %.c %.h: %.org
 	emacs --quick --no-init-file --batch --eval "(require 'org)" --eval '(org-babel-tangle-file "$^")'
@@ -14,7 +17,7 @@ SOURCE_FILES=$(wildcard *.org)
 %.c %.h %_f.f90: %.org
 	emacs --quick --no-init-file --batch --eval "(require 'org)" --eval '(org-babel-tangle-file "$^")'
 
-%.o: %.c 
+%.o: %.c
 	$(CC) $(CFLAGS) -c $*.c -o $*.o
 
 %.o: %.f90


### PR DESCRIPTION
Current `src/Makefile` does not have a default target. This is surprising for new users.

This PR adds a default target that untangles `.org` files and builds objects.

Instead of using `$(wildcard *.org)` to auto-detect `.org` files, we specify them manually. This is due to the fact that some `.org` files in `src/`, such as `README.org` will not generate object files.