### PR TITLE
Add a github action to test build automatically

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,17 @@
+name: test-build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make -C src/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # qmckl
+
+[![Build Status](https://github.com/TREX-CoE/qmckl/workflows/test-build/badge.svg?branch=main)
+
 Quantum Monte Carlo Kernel Library.
 
 See the [Wiki](https://github.com/TREX-CoE/qmckl/wiki) for more information.


### PR DESCRIPTION
This PR add a very simple workflow to test library build for each PR and commit using github-actions. We can later run to a more complex dedicated CI.