### PR TITLE
Test auto generate

### DIFF
--- a/src/orglib
+++ b/src/orglib
@@ -7,15 +7,17 @@ Function to get the value of a property.
 (pop x)
 #+end_src
 
+#+RESULTS: get_value
+
 
 Generates a C prototype
 #+NAME: generate_h
-#+BEGIN_SRC python :var d=[] :results output :noweb yes :wrap "src C :tangle qmckl.h :comments org"
+#+BEGIN_SRC python :var d=[] :var rettyp=[] :var fname=[] :results output :noweb yes :wrap "src C :tangle qmckl.h :comments org"
 const_d = {
     'in':    'const' 
     ,'input': 'const' 
-    ,'out': '' 
-    ,'output': ''
+    ,'out': 'const'
+    ,'output': 'const'
 }
 
 results = []
@@ -28,10 +30,10 @@ for typ, name, inout, _ in d:
 
 results=',\n'.join(results)
 
-typ = '<<get_value("Type")>>'
-name= '<<get_value("Name")>>'
+#typ = '<<get_value("Type")>>'
+#name= '<<get_value("Name")>>'
 template = f"""
-{typ} {name} ( {results} )
+{rettyp} {fname} ( {results} )
 """
 print(template)
 #+END_SRC

--- a/src/orglib
+++ b/src/orglib
@@ -10,8 +10,8 @@ Function to get the value of a property.
 #+RESULTS: get_value
 
 
-Generates a C prototype
-#+NAME: generate_h
+Generates a C header
+#+NAME: generate_header
 #+BEGIN_SRC python :var d=[] :var rettyp=[] :var fname=[] :results output :noweb yes :wrap "src C :tangle qmckl.h :comments org"
 const_d = {
     'in':    'const' 
@@ -30,11 +30,69 @@ for typ, name, inout, _ in d:
 
 results=',\n'.join(results)
 
-#typ = '<<get_value("Type")>>'
-#name= '<<get_value("Name")>>'
 template = f"""
 {rettyp} {fname} ( {results} )
 """
 print(template)
 #+END_SRC
 
+
+Generates a C interface
+#+NAME: generate_c_interface
+#+BEGIN_SRC python :var d=[] :var rettyp=[] :var fname=[] :results output :noweb yes :wrap "src f90 :tangle (fname).f :comments org"
+
+ctypeid_d = {
+    'integer'       :    'c_int32_t' ,
+    'character'     :    'c_char',
+    'real'          :    'c_float',
+    'integer*8'     :    'c_int64_t' ,
+    'real*8'        :    'c_double'
+}
+
+# Get the ctype for return type
+ctypeid = "("+ctypeid_d[rettyp]+")"
+rettypcopy = rettyp
+rettyp = rettyp + ctypeid
+
+# Set up function name
+fname_copy = fname
+fname_call = fname
+fname = " function " + fname
+
+results = ["& \n bind(C) result(info) \n use, intrinsic :: iso_c_binding \n implicit none"]
+namelist = ''
+first = True
+for typ, name, inout, _ in d:
+    if '[' in name:
+        inout = " , intent(" + inout +") ,       ::"
+        name = name.split('[')[0]
+    else:
+        inout = " , intent(" + inout +") , value ::"
+    if '*' in typ:
+        typ = typ.split('*')[0]
+    if first:
+        namelist = namelist + name
+        first = False
+    else:
+        namelist = namelist + " , " + name
+    ctypeid = "("+ctypeid_d[typ]+")"
+    typ = typ +  ctypeid
+    results += [ f"{typ} {inout} {name}" ]
+
+fname = fname + "(" + namelist + ")"
+fname_call = fname_call + "_f(" + namelist + ")"
+
+# Add function type
+results += [ f"{rettyp}, external :: {name}"]
+# Call function
+results += [ f"info = {fname_call}"]
+# End function
+results += [ f"end function {fname_copy}"]
+
+results='\n'.join(results)
+
+template = f"""
+{rettyp} {fname} {results}
+"""
+print(template)
+#+END_SRC

--- a/src/qmckl_ao.org
+++ b/src/qmckl_ao.org
@@ -1,3 +1,7 @@
+#+begin_src elisp :results none :noexport:
+(org-babel-lob-ingest "./orglib")
+#+end_src
+
 ** Atomic Orbitals
    :PROPERTIES:
    :f:        qmckl_ao.f90
@@ -49,6 +53,10 @@ MunitResult test_qmckl_ao() {
     \end{eqnarray*}
 
 **** ~qmckl_ao_power~
+     :PROPERTIES:
+     :Type:     qmckl_exit_code
+     :Name:     qmckl_ao_power
+     :END:
 
      Computes all  the powers of  the ~n~ input  data up to  the given
      maximum value given in input for each of the $n$ points:
@@ -63,7 +71,16 @@ MunitResult test_qmckl_ao() {
       | ~LMAX(n)~  | input  | Array containing the maximum power for each value |
       | ~P(LDP,n)~ | output | Array containing all the powers of ~X~            |
       | ~LDP~      | input  | Leading dimension of array ~P~                    |
-    
+
+      #+name: args
+     | qmckl_context | context   | in  | Global state                                      |
+     | int64_t       | n         | in  | Number of values                                  |
+     | double        | X[n]      | in  | Array containing the input values                 |
+     | int32_t       | LMAX[n]   | in  | Array containing the maximum power for each value |
+     | double        | P[LDP][n] | out | Array containing all the powers of ~X~            |
+     | int64_t       | LDP       | in  | Leading dimension of array ~P~                    |
+
+
 ***** Requirements
 
       - ~context~ is not 0
@@ -74,13 +91,22 @@ MunitResult test_qmckl_ao() {
       - ~LDP~ >= $\max_i$ ~LMAX[i]~
 
 ***** Header
-      #+BEGIN_SRC C :tangle (org-entry-get nil "h" t) 
-qmckl_exit_code qmckl_ao_power(const qmckl_context context,
-                const int64_t n, 
-                const double *X, const int32_t *LMAX,
-                const double *P, const int64_t LDP);
-      #+END_SRC
-    
+
+#+CALL: generate_h(d=args,rettyp=get_value("Type"),fname=get_value("Name"))
+
+#+RESULTS:
+#+begin_src C :tangle qmckl.h :comments org
+
+qmckl_exit_code qmckl_ao_power ( const qmckl_context context,
+const int64_t n,
+const double* X,
+const int32_t* LMAX,
+const double* P,
+const int64_t LDP )
+
+#+end_src
+
+
 ***** Source
       #+BEGIN_SRC f90 :tangle (org-entry-get nil "f" t) 
 integer function qmckl_ao_power_f(context, n, X, LMAX, P, ldp) result(info)

--- a/src/qmckl_context.org
+++ b/src/qmckl_context.org
@@ -1,3 +1,7 @@
+#+begin_src elisp :results none :noexport:
+(org-babel-lob-ingest "./orglib")
+#+end_src
+
 ** Context
    :PROPERTIES:
    :c:        qmckl_context.c
@@ -359,6 +363,10 @@ COEFFICIENT = [ 0.006068, 0.045308, 0.202822, 0.503903, 0.383421,
      #+END_EXAMPLE
 
 **** ~qmckl_context_update_ao_basis~
+     :PROPERTIES:
+     :Type:     qmckl_exit_code
+     :Name:     qmckl_context_update_ao_basis
+     :END:
 
      Updates the data describing the AO basis set into the context.
 
@@ -373,15 +381,38 @@ COEFFICIENT = [ 0.006068, 0.045308, 0.202822, 0.503903, 0.383421,
      | ~EXPONENT(prim_num)~          | Array of exponents                                                   |
      | ~COEFFICIENT(prim_num)~       | Array of coefficients                                                |
 
-     #+BEGIN_SRC C :comments org :tangle (org-entry-get nil "h" t) 
-qmckl_exit_code
-qmckl_context_update_ao_basis(qmckl_context   context     , const char      type,
-                              const int64_t   shell_num   , const int64_t   prim_num, 
-                              const int64_t * SHELL_CENTER, const int32_t * SHELL_ANG_MOM,
-                              const double  * SHELL_FACTOR, const int64_t * SHELL_PRIM_NUM,
-                              const int64_t * SHELL_PRIM_INDEX,
-                              const double  * EXPONENT    , const double  * COEFFICIENT);
-     #+END_SRC
+     #+name: args
+     | qmckl_context | context                     | in | Global state                                                         |
+     | char          | type                        | in | Gaussian or Slater                                                   |
+     | int64_t       | shell_num                   | in | Number of shells                                                     |
+     | int64_t       | prim_num                    | in | Total number of primitives                                           |
+     | int64_t       | SHELL_CENTER[shell_num]     | in | Id of the nucleus on which the shell is centered                     |
+     | int32_t       | SHELL_ANG_MOM[shell_num]    | in | Id of the nucleus on which the shell is centered                     |
+     | double        | SHELL_FACTOR[shell_num]     | in | Normalization factor for the shell                                   |
+     | int64_t       | SHELL_PRIM_NUM[shell_num]   | in | Number of primitives in the shell                                    |
+     | int64_t       | SHELL_PRIM_INDEX[shell_num] | in | Address of the first primitive of the shelll in the ~EXPONENT~ array |
+     | double        | EXPONENT[prim_num]          | in | Array of exponents                                                   |
+     | double        | COEFFICIENT[prim_num]       | in | Array of coefficients                                                |
+
+#+CALL: generate_h(d=args,rettyp=get_value("Type"),fname=get_value("Name"))
+
+#+RESULTS:
+#+begin_src C :tangle qmckl.h :comments org
+
+qmckl_exit_code qmckl_context_update_ao_basis ( const qmckl_context context,
+const char type,
+const int64_t shell_num,
+const int64_t prim_num,
+const int64_t* SHELL_CENTER,
+const int32_t* SHELL_ANG_MOM,
+const double* SHELL_FACTOR,
+const int64_t* SHELL_PRIM_NUM,
+const int64_t* SHELL_PRIM_INDEX,
+const double* EXPONENT,
+const double* COEFFICIENT )
+
+#+end_src
+
 
 ***** Source
       #+BEGIN_SRC C :tangle (org-entry-get nil "c" t)

--- a/src/qmckl_distance.org
+++ b/src/qmckl_distance.org
@@ -26,7 +26,8 @@ MunitResult test_qmckl_distance() {
 
 **** ~qmckl_distance_sq~
      :PROPERTIES:
-     :Type:     qmckl_exit_code
+     :CRetType: qmckl_exit_code
+     :FRetType: integer
      :Name:     qmckl_distance_sq
      :END:
 
@@ -37,18 +38,6 @@ MunitResult test_qmckl_distance() {
      \]
 
 ***** Arguments
-
-      | ~context~  | input  | Global state                                 |
-      | ~transa~   | input  | Array ~A~ is ~N~: Normal, ~T~: Transposed   |
-      | ~transb~   | input  | Array ~B~ is ~N~: Normal, ~T~: Transposed   |
-      | ~m~        | input  | Number of points in the first set            |
-      | ~n~        | input  | Number of points in the second set           |
-      | ~A(lda,3)~ | input  | Array containing the $m \times 3$ matrix $A$ |
-      | ~lda~      | input  | Leading dimension of array ~A~               |
-      | ~B(ldb,3)~ | input  | Array containing the $n \times 3$ matrix $B$ |
-      | ~ldb~      | input  | Leading dimension of array ~B~               |
-      | ~C(ldc,n)~ | output | Array containing the $m \times n$ matrix $C$ |
-      | ~ldc~      | input  | Leading dimension of array ~C~               |
 
       #+NAME: args
     | qmckl_context | context      | in  | Global state                                 |
@@ -83,7 +72,7 @@ MunitResult test_qmckl_distance() {
       This function might be more efficient when ~A~ and ~B~ are
       transposed.
 
-#+CALL: generate_h(d=args,rettyp=get_value("Type"),fname=get_value("Name"))
+#+CALL: generate_header(d=args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
 #+RESULTS:
 #+begin_src C :tangle qmckl.h :comments org
@@ -103,6 +92,19 @@ const int64_t ldc )
 #+end_src
 
 ***** Source
+      #+NAME: argsF
+    | integer*8 | context      | in  | Global state                                 |
+    | character | transa       | in  | Array ~A~ is ~N~: Normal, ~T~: Transposed    |
+    | character | transb       | in  | Array ~B~ is ~N~: Normal, ~T~: Transposed    |
+    | integer*8 | m            | in  | Number of points in the first set            |
+    | integer*8 | n            | in  | Number of points in the second set           |
+    | real*8    | A[lda][*]    | in  | Array containing the $m \times 3$ matrix $A$ |
+    | integer*8 | lda          | in  | Leading dimension of array ~A~               |
+    | real*8    | B[ldd][*]    | in  | Array containing the $n \times 3$ matrix $B$ |
+    | integer*8 | ldb          | in  | Leading dimension of array ~B~               |
+    | real*8    | C[ldc][*]    | out | Array containing the $m \times n$ matrix $C$ |
+    | integer*8 | ldc          | in  | Leading dimension of array ~C~               |
+
       #+BEGIN_SRC f90 :tangle qmckl_distance.f90
 integer function qmckl_distance_sq_f(context, transa, transb, m, n, A, LDA, B, LDB, C, LDC) result(info)
   implicit none
@@ -231,6 +233,32 @@ end function qmckl_distance_sq_f
       #+END_SRC
 
 ***** C interface                                                  :noexport:
+#+CALL: generate_c_interface(d=argsF,rettyp=get_value("FRetType"),fname=get_value("Name"))
+
+#+RESULTS:
+#+begin_src f90 :tangle (fname).f :comments org
+
+integer(c_int32_t)  function qmckl_distance_sq(context , transa , transb , m , n , A , lda , B , ldb , C , ldc) &
+ bind(C) result(info)
+ use, intrinsic :: iso_c_binding
+ implicit none
+integer(c_int32_t)  , intent(in) , value :: context
+character(c_char)  , intent(in) , value :: transa
+character(c_char)  , intent(in) , value :: transb
+integer(c_int32_t)  , intent(in) , value :: m
+integer(c_int32_t)  , intent(in) , value :: n
+real(c_float)  , intent(in) ,       :: A
+integer(c_int32_t)  , intent(in) , value :: lda
+real(c_float)  , intent(in) ,       :: B
+integer(c_int32_t)  , intent(in) , value :: ldb
+real(c_float)  , intent(out) ,       :: C
+integer(c_int32_t)  , intent(in) , value :: ldc
+integer(c_int32_t), external :: ldc
+info = qmckl_distance_sq_f(context , transa , transb , m , n , A , lda , B , ldb , C , ldc)
+end function qmckl_distance_sq
+
+#+end_src
+
       #+BEGIN_SRC f90 :tangle qmckl_distance.f90
 integer(c_int32_t) function qmckl_distance_sq(context, transa, transb, m, n, A, LDA, B, LDB, C, LDC) &
      bind(C) result(info)

--- a/src/qmckl_distance.org
+++ b/src/qmckl_distance.org
@@ -1,3 +1,7 @@
+#+begin_src elisp :results none
+(org-babel-lob-ingest "./orglib")
+#+end_src
+
 ** Computation of distances
 
  Function for the computation of distances between particles.
@@ -60,73 +64,6 @@ MunitResult test_qmckl_distance() {
     | int64_t       | ldc          | in  | Leading dimension of array ~C~               |
 
 
-#+begin_src sh :results drawer :exports none :noindent
-cat orglib
-#+end_src
-
-#+RESULTS:
-:results:
-# -*- mode: org -*-
-   
-Function to get the value of a property.
-#+NAME: get_value
-#+begin_src elisp :var key="Type"
-(setq x (org-property-values key))
-(pop x)
-#+end_src
-
-
-Generates a C prototype
-#+NAME: generate_h
-#+BEGIN_SRC python :var d=[] :results output :noweb yes :wrap "src C :tangle qmckl.h :comments org"
-const_d = {
-    'in':    'const' 
-    ,'input': 'const' 
-    ,'out': '' 
-    ,'output': ''
-}
-
-results = []
-for typ, name, inout, _ in d:
-    if '[' in name:
-        typ = typ+"*"
-        name = name.split('[')[0]
-    const = const_d[inout]
-    results += [ f"{const} {typ} {name}" ]
-
-results=',\n'.join(results)
-
-typ = '<<get_value("Type")>>'
-name= '<<get_value("Name")>>'
-template = f"""
-{typ} {name} ( {results} )
-"""
-print(template)
-#+END_SRC
-
-:end:
-
-#+CALL: generate_h(d=args)
-
-#+RESULTS:
-#+begin_src C :tangle qmckl.h :comments org
-
-qmckl_exit_code qmckl_distance_sq ( const qmckl_context context,
-const char transa,
-const char transb,
-const int64_t m,
-const int64_t n,
-const double* A,
-const int64_t lda,
-const double* B,
-const int64_t ldb,
- double* C,
-const int64_t ldc )
-
-#+end_src
-
-
-
 ***** Requirements
 
       - ~context~ is not 0
@@ -146,14 +83,24 @@ const int64_t ldc )
       This function might be more efficient when ~A~ and ~B~ are
       transposed.
 
-      #+BEGIN_SRC C :comments org :tangle qmckl.h
-qmckl_exit_code qmckl_distance_sq(const qmckl_context context,
-                                  const char transa, const char transb,
-                                  const int64_t m, const int64_t n,
-                                  const double *A, const int64_t lda,
-                                  const double *B, const int64_t ldb,
-                                  const double *C, const int64_t ldc);
-      #+END_SRC
+#+CALL: generate_h(d=args,rettyp=get_value("Type"),fname=get_value("Name"))
+
+#+RESULTS:
+#+begin_src C :tangle qmckl.h :comments org
+
+qmckl_exit_code qmckl_distance_sq ( const qmckl_context context,
+const char transa,
+const char transb,
+const int64_t m,
+const int64_t n,
+const double* A,
+const int64_t lda,
+const double* B,
+const int64_t ldb,
+const double* C,
+const int64_t ldc )
+
+#+end_src
 
 ***** Source
       #+BEGIN_SRC f90 :tangle qmckl_distance.f90

--- a/src/qmckl_distance.org
+++ b/src/qmckl_distance.org
@@ -1,4 +1,4 @@
-#+begin_src elisp :results none
+#+begin_src elisp :results none :noexport:
 (org-babel-lob-ingest "./orglib")
 #+end_src
 


### PR DESCRIPTION
**[WIP] Automatically generate c and fortran interface with given documentation.** Closes #8 

The c and fortran inteface of qmckl can be set up to be autogenerated from the documentation of the functions.

There are multiple advantages of this strategy which are as follows:

- [x] Consistent interface generation
- [ ] Consistent conventions of function names
- [ ] Consistent conventions for arguments
- [ ] Documentation is by construction up to date with the code
- [ ] Users and developers are not required to write the interface thus reducing hand written lines of code

Some important points that need to be stressed while adopting this strategy are as follows:

- [ ] New users and developers need to be introduced to the documentation procedure
- [ ] A standard has to be clearly documented and defined
