### PR TITLE
Make sure qmckl.h can be imported from C++

### DIFF
--- a/tools/build_qmckl_h.sh
+++ b/tools/build_qmckl_h.sh
@@ -85,6 +85,10 @@ cat << EOF > ${OUTPUT}
 #ifndef __QMCKL_H__
 #define __QMCKL_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -100,6 +104,9 @@ do
 done
 
 cat << EOF >> ${OUTPUT}
+#ifdef __cplusplus
+}
+#endif
 #endif
 EOF
 


### PR DESCRIPTION
When `qmckl.h` is included in a C++ file wrap the definitions in an `extern "C"` block to avoid mangling.
This avoid surprises for our users that will call qmckl function from a C++ program.

(See for example here for an explanation of why this is a good idea https://lucumr.pocoo.org/2013/8/18/beautiful-native-libraries/)