### PR TITLE
Sherman determinant

### DIFF
--- a/org/qmckl_sherman_morrison_woodbury.org
+++ b/org/qmckl_sherman_morrison_woodbury.org
@@ -66,12 +66,12 @@ int main() {
    #+NAME: qmckl_sherman_morrison_args
    | qmckl_context | context                  | in    | Global state                                         |
    | uint64_t      | Dim                      | in    | Leading dimension of Slater_inv                      |
-   | uint64_t      | N_updates                | in    | Number of rank-1 updates to be applied to Slater_inv |
+  | uint64_t      | N_updates                | in    | Number of rank-1 updates to be applied to Slater_inv |
    | double        | Updates[N_updates*Dim]   | in    | Array containing the updates                         |
    | uint64_t      | Updates_index[N_updates] | in    | Array containing the rank-1 updates                  |
    | double        | breakdown                | in    | Break-down parameter on which to fail or not         |
    | double        | Slater_inv[Dim*Dim]      | inout | Array containing the inverse of a Slater-matrix      |
-   | double*       | determinant              | inout | Determinant of the Slater-matrix                      |
+   | double*       | determinant              | inout | Determinant of the Slater-matrix                     |
 
 *** Requirements
 
@@ -97,7 +97,7 @@ int main() {
 	  const uint64_t* Updates_index,
 	  const double breakdown,
 	  double* Slater_inv,
-    double* determinant);
+	  double* determinant);
     #+end_src
 
 *** C source
@@ -334,7 +334,7 @@ assert(rc == QMCKL_SUCCESS);
 	  const uint64_t* Updates_index,
 	  const double breakdown,
 	  double* Slater_inv,
-    double* determinant);
+	  double* determinant);
     #+end_src
 
 *** C source
@@ -768,7 +768,7 @@ assert(rc == QMCKL_SUCCESS);
 	  const uint64_t* Updates_index,
 	  const double breakdown,
 	  double* Slater_inv,
-    double* determinant);
+	  double* determinant);
     #+end_src
 
 *** C source
@@ -927,7 +927,7 @@ assert(rc == QMCKL_SUCCESS);
 	  const uint64_t* Updates_index,
 	  const double breakdown,
 	  double* Slater_inv,
-    double* determinant);
+	  double* determinant);
     #+end_src
 
 *** C source
@@ -1136,7 +1136,7 @@ These functions can only be used internally by the kernels in this module.
 	  double* later_updates,
 	  uint64_t* later_index,
 	  uint64_t* later,
-    double* determinant );
+	  double* determinant);
     #+end_src
 
 *** C source


### PR DESCRIPTION
Modify Sherman Morrisson Woodbury kernels so the determinant is updated at the same time the updates are applied.
The [matrix determinant lemma](https://en.wikipedia.org/wiki/Matrix_determinant_lemma) makes this update easy to do.

The final determinant is obtained by multiplying the initial determinant by the product of all the determinants of the denominators in the SM-WB formulas.