### PR TITLE
Fix TREXIO installation in the Verificarlo workflow

### DIFF
--- a/.github/workflows/vfc_test_workflow.yml
+++ b/.github/workflows/vfc_test_workflow.yml
@@ -33,7 +33,7 @@ jobs:
           wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.0.tar.gz
           tar -zxf trexio-${VERSION}.0.tar.gz
           cd trexio-${VERSION}.0
-          ./configure --prefix=/usr CC="verificarlo-f" FC="verificarlo-f"
+          ./configure --prefix=/usr CC="verificarlo-c" FC="verificarlo-f"
           make -j4
           sudo make install
 

--- a/.github/workflows/vfc_test_workflow.yml
+++ b/.github/workflows/vfc_test_workflow.yml
@@ -27,15 +27,16 @@ jobs:
           apt update
           apt -y install emacs pkg-config wget libhdf5-dev libblas-dev liblapack-dev
 
-      # - name: Install trexio
-        # run: |
-        # export VERSION=2.0
-        # wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.0.tar.gz
-        # tar -zxf trexio-${VERSION}.0.tar.gz
-        # cd trexio-${VERSION}.0
-        # ./configure --prefix=/usr CC="verificarlo-c" FC="verificarlo-f"
-        # make -j4
-        # sudo make install
+      - name: Install trexio
+        run: |
+        export VERSION=1.1.0
+        wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.tar.gz
+        tar -zxf trexio-${VERSION}.tar.gz
+        cd trexio-${VERSION}
+        ./configure --prefix=/usr CC="gcc-7" FC="gfortran-7"
+        # modify LDFLAGS to include -lhdf5_hl because autoconf sometime fails to detect the HL component
+        make LDFLAGS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl"
+        make install
 
       - name: Run tests
         run: vfc_ci test -g -r

--- a/.github/workflows/vfc_test_workflow.yml
+++ b/.github/workflows/vfc_test_workflow.yml
@@ -29,14 +29,14 @@ jobs:
 
       - name: Install trexio
         run: |
-        export VERSION=1.1.0
-        wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.tar.gz
-        tar -zxf trexio-${VERSION}.tar.gz
-        cd trexio-${VERSION}
-        ./configure --prefix=/usr CC="gcc-7" FC="gfortran-7"
-        # modify LDFLAGS to include -lhdf5_hl because autoconf sometime fails to detect the HL component
-        make LDFLAGS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl"
-        make install
+          export VERSION=1.1.0
+          wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.tar.gz
+          tar -zxf trexio-${VERSION}.tar.gz
+          cd trexio-${VERSION}
+          ./configure --prefix=/usr CC="gcc-7" FC="gfortran-7"
+          # modify LDFLAGS to include -lhdf5_hl because autoconf sometime fails to detect the HL component
+          make LDFLAGS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl"
+          make install
 
       - name: Run tests
         run: vfc_ci test -g -r

--- a/.github/workflows/vfc_test_workflow.yml
+++ b/.github/workflows/vfc_test_workflow.yml
@@ -29,12 +29,12 @@ jobs:
 
       - name: Install trexio
         run: |
-          export VERSION=1.1.0
-          wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.tar.gz
-          tar -zxf trexio-${VERSION}.tar.gz
-          cd trexio-${VERSION}
-          ./configure --prefix=/usr
-          make -j 8
+          export VERSION=2.0
+          wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.0.tar.gz
+          tar -zxf trexio-${VERSION}.0.tar.gz
+          cd trexio-${VERSION}.0
+          ./configure --prefix=/usr CC="verificarlo-f" FC="verificarlo-f"
+          make -j4
           sudo make install
 
       - name: Run tests

--- a/.github/workflows/vfc_test_workflow.yml
+++ b/.github/workflows/vfc_test_workflow.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           ln -s /usr/bin/python3 /usr/bin/python
           apt update
-          apt -y install emacs pkg-config wget libhdf5-dev
+          apt -y install emacs pkg-config wget libhdf5-dev libblas-dev liblapack-dev
 
       # - name: Install trexio
         # run: |

--- a/.github/workflows/vfc_test_workflow.yml
+++ b/.github/workflows/vfc_test_workflow.yml
@@ -27,15 +27,15 @@ jobs:
           apt update
           apt -y install emacs pkg-config wget libhdf5-dev
 
-      - name: Install trexio
-        run: |
-          export VERSION=2.0
-          wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.0.tar.gz
-          tar -zxf trexio-${VERSION}.0.tar.gz
-          cd trexio-${VERSION}.0
-          ./configure --prefix=/usr CC="verificarlo-c" FC="verificarlo-f"
-          make -j4
-          sudo make install
+      # - name: Install trexio
+        # run: |
+        # export VERSION=2.0
+        # wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.0.tar.gz
+        # tar -zxf trexio-${VERSION}.0.tar.gz
+        # cd trexio-${VERSION}.0
+        # ./configure --prefix=/usr CC="verificarlo-c" FC="verificarlo-f"
+        # make -j4
+        # sudo make install
 
       - name: Run tests
         run: vfc_ci test -g -r

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 export srcdir="."
-${PYTHON} ${srcdir}/tools/build_makefile.py
+python ${srcdir}/tools/build_makefile.py
 autoreconf -i -Wall --no-recursive

--- a/tools/build_makefile.py
+++ b/tools/build_makefile.py
@@ -250,8 +250,8 @@ def main():
     tmp = "EXTRA_DIST += "
     r = subprocess.check_output("git ls-tree --name-only -r HEAD".split())
     for line in r.splitlines():
-       if "share/qmckl/test_data/" in line:
-         tmp += " \\\n   " + line
+       if b"share/qmckl/test_data/" in line:
+         tmp += " \\\n   " + line.decode('utf8')
     tmp += "\n"
     output += tmp.split("\n")
 

--- a/tools/ci_install.sh
+++ b/tools/ci_install.sh
@@ -8,9 +8,10 @@ export VERSION=2.0
 wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.0.tar.gz
 tar -zxf trexio-${VERSION}.0.tar.gz
 cd trexio-${VERSION}.0
-./configure --prefix=/usr --host=x86_64 CC="verificarlo-c" FC="verificarlo-f"
-make -j4
-sudo make install
+./configure --prefix=/usr CC="gcc-7" FC="gfortran-7"
+# modify LDFLAGS to include -lhdf5_hl because autoconf sometime fails to detect the HL component
+make LDFLAGS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl"
+make install
 cd ..
 
 ./autogen.sh

--- a/tools/ci_install.sh
+++ b/tools/ci_install.sh
@@ -4,6 +4,15 @@
 # the library dependencies and build it with Verificarlo with vfc_probes support
 # enabled.
 
+export VERSION=2.0
+wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.0.tar.gz
+tar -zxf trexio-${VERSION}.0.tar.gz
+cd trexio-${VERSION}.0
+./configure --prefix=/usr --host=x86_64 CC="verificarlo-c" FC="verificarlo-f"
+make -j4
+sudo make install
+cd ..
+
 ./autogen.sh
 QMCKL_DEVEL=1 ./configure --prefix=$PWD/_install \
 --enable-silent-rules --enable-maintainer-mode --enable-vfc_ci --host=x86_64 \

--- a/tools/ci_install.sh
+++ b/tools/ci_install.sh
@@ -4,16 +4,6 @@
 # the library dependencies and build it with Verificarlo with vfc_probes support
 # enabled.
 
-export VERSION=2.0
-wget https://github.com/TREX-CoE/trexio/releases/download/v${VERSION}/trexio-${VERSION}.0.tar.gz
-tar -zxf trexio-${VERSION}.0.tar.gz
-cd trexio-${VERSION}.0
-./configure --prefix=/usr CC="gcc-7" FC="gfortran-7"
-# modify LDFLAGS to include -lhdf5_hl because autoconf sometime fails to detect the HL component
-make LDFLAGS="-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lhdf5_hl"
-make install
-cd ..
-
 ./autogen.sh
 QMCKL_DEVEL=1 ./configure --prefix=$PWD/_install \
 --enable-silent-rules --enable-maintainer-mode --enable-vfc_ci --host=x86_64 \


### PR DESCRIPTION
`Install trexio` was failing due to the missing C compiler (cause the workflow is running in a `verificarlo` container). 

- Fix this by configuring TREXIO with GNU compilers (gcc-7 and gfortran-7) that are available in the `verificarlo` container.
- Also install BLAS and LAPACK due to the recent change in the `configure.ac` of QMCkl (now both libs are required)
- Fix bug due to the use of byte-strings to get the `EXTRA_DIST` in `tools/build_makefile.py`

**TODO** : upgrade the TREXIO version in `.yml` files when QMCkl is upgraded to use the recent TREXIO basis set format from v.2.0.
