### PR TITLE
Test QMCkl with the latest TREXIO + MacOS CI

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -80,10 +80,10 @@ jobs:
         ./configure FC=gfortran-10 --prefix=${PWD}/_install --enable-silent-rules
         make -j 4
         make install
-        export PKG_CONFIG_PATH=${PWD}/_install/lib/pkgconfig:$PKG_CONFIG_PATH
 
     - name: Build QMCkl
       run: |
+        export PKG_CONFIG_PATH=${PWD}/trexio/_install/lib/pkgconfig:$PKG_CONFIG_PATH
         ./autogen.sh
         ./configure FC=gfortran-10 --enable-silent-rules --enable-debug
         make -j 4

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -72,12 +72,22 @@ jobs:
     - uses: actions/checkout@v2
     - name: install dependencies
       run: brew install emacs hdf5 automake pkg-config
+    - name: Symlink gfortran (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        # make sure gfortran is available
+        # https://github.com/actions/virtual-environments/issues/2524
+        # https://github.com/cbg-ethz/dce/blob/master/.github/workflows/pkgdown.yaml
+        sudo ln -s /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
+        sudo mkdir /usr/local/gfortran
+        sudo ln -s /usr/local/Cellar/gcc@10/*/lib/gcc/10 /usr/local/gfortran/lib
+        gfortran --version
     - name: Install the latest TREXIO from the GitHub clone
       run: |
         git clone https://github.com/TREX-CoE/trexio.git
         cd trexio
         ./autogen.sh
-        ./configure FC=gfortran-10 --prefix=${PWD}/_install --enable-silent-rules
+        ./configure FC=gfortran --prefix=${PWD}/_install --enable-silent-rules
         make -j 4
         make install
 
@@ -85,7 +95,7 @@ jobs:
       run: |
         export PKG_CONFIG_PATH=${PWD}/trexio/_install/lib/pkgconfig:$PKG_CONFIG_PATH
         ./autogen.sh
-        ./configure FC=gfortran-10 --enable-silent-rules --enable-debug
+        ./configure F77=gfortran FC=gfortran --enable-silent-rules --enable-debug
         make -j 4
 
     - name: Run test

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -18,32 +18,40 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install emacs autoconf libhdf5-dev
 
-    - name: Install trexio
+    #- name: Install trexio from the distribution tarball
+    #  run: |
+    #    export TAG=v2.1.0
+    #    export VERSION=2.1.0
+    #    wget https://github.com/TREX-CoE/trexio/releases/download/${TAG}/trexio-${VERSION}.tar.gz
+    #    tar -zxf trexio-${VERSION}.tar.gz
+    #    cd trexio-${VERSION}
+    #    ./configure --prefix=/usr
+    #    make -j 4
+    #    sudo make install
+    - name: Install the latest TREXIO from the GitHub clone
       run: |
-        export TAG=v2.1.0
-        export VERSION=2.1.0
-        wget https://github.com/TREX-CoE/trexio/releases/download/${TAG}/trexio-${VERSION}.tar.gz
-        tar -zxf trexio-${VERSION}.tar.gz
-        cd trexio-${VERSION}
+        git clone https://github.com/TREX-CoE/trexio.git
+        cd trexio
+        ./autogen.sh
         ./configure --prefix=/usr
-        make -j 8
+        make -j 4
         sudo make install
 
-    - name: Build
+    - name: Build QMCkl
       run: |
         ./autogen.sh
         ./configure --enable-silent-rules --enable-debug
-        make -j 8
+        make -j 4
 
     - name: Run test
       run: |
-        make -j check
+        make -j 4 check
 
     - name: Archive test log file
       if: failure()
       uses: actions/upload-artifact@v2
       with:
-        name: test-report
+        name: test-report-ubuntu
         path: test-suite.log
 
     - name: Dist test
@@ -54,34 +62,42 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v2
       with:
-        name: dist-report
+        name: dist-report-ubuntu
         path: test-suite.log
 
-
 #  x86_macos:
-#
+
 #    runs-on: macos-latest
 #    name: x86 MacOS latest
-#
+
 #    steps:
 #    - uses: actions/checkout@v2
 #    - name: install dependencies
 #      run: |
-#        brew install gfortran-10
 #        brew install emacs
-#        brew install autoconf automake libtool
-#    - name: install trexio
+#        brew install hdf5
+#        brew install automake
+#    - name: Install the latest TREXIO from the GitHub clone
 #      run: |
-#        wget https://github.com/TREX-CoE/trexio/releases/download/v1.0/trexio-1.0.0.tar.gz
-#        tar -zxf trexio-1.0.0.tar.gz
-#        cd trexio-1.0.0
-#        ./configure
-#        make -j 8
+#        git clone https://github.com/TREX-CoE/trexio.git
+#        cd trexio
+#        ./autogen.sh
+#        ./configure FC=gfortran-10 --prefix=/usr --enable-silent-rules
+#        make -j 4
 #        sudo make install
-#    - name: Run test
+
+#    - name: Build QMCkl
 #      run: |
 #        ./autogen.sh
-#        ./configure --enable-silent-rules --enable-debug
-#        make -j 8
-#        make -j check
-#        make distcheck
+#        ./configure FC=gfortran-10 --enable-silent-rules --enable-debug
+#        make -j 4
+
+#    - name: Run test
+#      run: make -j 4 check
+
+#    - name: Archive test log file
+#      if: failure()
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: test-report-macos
+#        path: test-suite.log

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -44,8 +44,7 @@ jobs:
         make -j 4
 
     - name: Run test
-      run: |
-        make -j 4 check
+      run: make -j 4 check
 
     - name: Archive test log file
       if: failure()
@@ -55,8 +54,7 @@ jobs:
         path: test-suite.log
 
     - name: Dist test
-      run: |
-        make distcheck
+      run: make distcheck
 
     - name: Archive test log file
       if: failure()
@@ -65,39 +63,36 @@ jobs:
         name: dist-report-ubuntu
         path: test-suite.log
 
-#  x86_macos:
+  x86_macos:
 
-#    runs-on: macos-latest
-#    name: x86 MacOS latest
+    runs-on: macos-latest
+    name: x86 MacOS latest
 
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: install dependencies
-#      run: |
-#        brew install emacs
-#        brew install hdf5
-#        brew install automake
-#    - name: Install the latest TREXIO from the GitHub clone
-#      run: |
-#        git clone https://github.com/TREX-CoE/trexio.git
-#        cd trexio
-#        ./autogen.sh
-#        ./configure FC=gfortran-10 --prefix=/usr --enable-silent-rules
-#        make -j 4
-#        sudo make install
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependencies
+      run: brew install emacs hdf5 automake
+    - name: Install the latest TREXIO from the GitHub clone
+      run: |
+        git clone https://github.com/TREX-CoE/trexio.git
+        cd trexio
+        ./autogen.sh
+        ./configure FC=gfortran-10 --prefix=/usr --enable-silent-rules
+        make -j 4
+        sudo make install
 
-#    - name: Build QMCkl
-#      run: |
-#        ./autogen.sh
-#        ./configure FC=gfortran-10 --enable-silent-rules --enable-debug
-#        make -j 4
+    - name: Build QMCkl
+      run: |
+        ./autogen.sh
+        ./configure FC=gfortran-10 --enable-silent-rules --enable-debug
+        make -j 4
 
-#    - name: Run test
-#      run: make -j 4 check
+    - name: Run test
+      run: make -j 4 check
 
-#    - name: Archive test log file
-#      if: failure()
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: test-report-macos
-#        path: test-suite.log
+    - name: Archive test log file
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-report-macos
+        path: test-suite.log

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -80,7 +80,7 @@ jobs:
         ./configure FC=gfortran-10 --prefix=${PWD}/_install --enable-silent-rules
         make -j 4
         make install
-        export PKG_CONFIG_PATH=${PWD}/_install:$PKG_CONFIG_PATH
+        export PKG_CONFIG_PATH=${PWD}/_install/lib/pkgconfig:$PKG_CONFIG_PATH
 
     - name: Build QMCkl
       run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -71,15 +71,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install dependencies
-      run: brew install emacs hdf5 automake
+      run: brew install emacs hdf5 automake pkg-config
     - name: Install the latest TREXIO from the GitHub clone
       run: |
         git clone https://github.com/TREX-CoE/trexio.git
         cd trexio
         ./autogen.sh
-        ./configure FC=gfortran-10 --prefix=/usr --enable-silent-rules
+        ./configure FC=gfortran-10 --prefix=${PWD}/_install --enable-silent-rules
         make -j 4
-        sudo make install
+        make install
+        export PKG_CONFIG_PATH=${PWD}/_install:$PKG_CONFIG_PATH
 
     - name: Build QMCkl
       run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -72,6 +72,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: install dependencies
       run: brew install emacs hdf5 automake pkg-config
+      
     - name: Symlink gfortran (macOS)
       if: runner.os == 'macOS'
       run: |
@@ -82,12 +83,13 @@ jobs:
         sudo mkdir /usr/local/gfortran
         sudo ln -s /usr/local/Cellar/gcc@10/*/lib/gcc/10 /usr/local/gfortran/lib
         gfortran --version
+
     - name: Install the latest TREXIO from the GitHub clone
       run: |
         git clone https://github.com/TREX-CoE/trexio.git
         cd trexio
         ./autogen.sh
-        ./configure FC=gfortran --prefix=${PWD}/_install --enable-silent-rules
+        ./configure --prefix=${PWD}/_install --enable-silent-rules
         make -j 4
         make install
 
@@ -95,7 +97,7 @@ jobs:
       run: |
         export PKG_CONFIG_PATH=${PWD}/trexio/_install/lib/pkgconfig:$PKG_CONFIG_PATH
         ./autogen.sh
-        ./configure F77=gfortran FC=gfortran --enable-silent-rules --enable-debug
+        ./configure --enable-silent-rules --enable-debug
         make -j 4
 
     - name: Run test

--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,6 @@ AC_PROG_CC
 m4_version_prereq([2.70],[], [AC_PROG_CC_C99])
 AS_IF([test "$ac_cv_prog_cc_c99" = "no"], [AC_MSG_ERROR([The compiler does not support C99])])
 AC_PROG_CC_C_O
-AC_PROG_F77
 AC_PROG_FC
 AC_PROG_FC_C_O
 AC_FC_SRCEXT([f90])

--- a/share/qmckl/test_data/chbrclf/metadata.txt
+++ b/share/qmckl/test_data/chbrclf/metadata.txt
@@ -2,9 +2,10 @@ rank_metadata_code 0
 rank_metadata_author 0
 metadata_code_num_isSet 0 
 metadata_author_num_isSet 0 
+metadata_unsafe_isSet 0 
 len_metadata_package_version 6
 metadata_package_version
-2.0.0
+2.2.0
 len_metadata_description 0
 metadata_description
 metadata_code


### PR DESCRIPTION
`test_qmckl_trexio` was failing with recent versions of TREXIO due to the modifications in the `metadata` group which made the TREXIO file in `share/qmckl/test_data/chbrclf` incompatible (see [TREXIO issue #81](https://github.com/TREX-CoE/trexio/issues/81)). 

This PR fixes this by:
- Updating `metadata` group in the `share/qmckl/test_data/chbrclf`
- Change the GitHub actions to install the latest TREXIO (from the GitHub repo clone)

In the meantime, I also enabled the GitHub CI for MacOS.

**Note:** I removed rather useless `AC_PROG_F77` check from `configure.ac` which requires the `f77` or some other default Fortran 77 compiler name. I do not see the point of checking this since QMCkl at present does not have Fortran 77 code.