### PR TITLE
Reorder indices in tensors for Jastrow.

### DIFF
--- a/org/qmckl_jastrow.org
+++ b/org/qmckl_jastrow.org
@@ -678,9 +678,9 @@ qmckl_exit_code qmckl_get_jastrow_cord_vector (const qmckl_context context, doub
 qmckl_exit_code  qmckl_set_jastrow_ord_num           (qmckl_context context, const int64_t aord_num, const int64_t bord_num, const int64_t cord_num);
 qmckl_exit_code  qmckl_set_jastrow_type_nucl_num     (qmckl_context context, const int64_t type_nucl_num);
 qmckl_exit_code  qmckl_set_jastrow_type_nucl_vector  (qmckl_context context, const int64_t* type_nucl_vector, const int64_t nucl_num);
-qmckl_exit_code  qmckl_set_jastrow_aord_vector       (qmckl_context context, const double * aord_vector);
-qmckl_exit_code  qmckl_set_jastrow_bord_vector       (qmckl_context context, const double * bord_vector);
-qmckl_exit_code  qmckl_set_jastrow_cord_vector       (qmckl_context context, const double * cord_vector);
+qmckl_exit_code  qmckl_set_jastrow_aord_vector       (qmckl_context context, const double * aord_vector, int64_t size_max);
+qmckl_exit_code  qmckl_set_jastrow_bord_vector       (qmckl_context context, const double * bord_vector, int64_t size_max);
+qmckl_exit_code  qmckl_set_jastrow_cord_vector       (qmckl_context context, const double * cord_vector, int64_t size_max);
    #+end_src
 
    #+NAME:pre2
@@ -804,7 +804,7 @@ qmckl_exit_code qmckl_set_jastrow_type_nucl_vector(qmckl_context context, int64_
   <<post2>>
 }
 
-qmckl_exit_code qmckl_set_jastrow_aord_vector(qmckl_context context, double const * aord_vector) {
+qmckl_exit_code qmckl_set_jastrow_aord_vector(qmckl_context context, double const * aord_vector, int64_t size_max) {
 <<pre2>>
 
   int32_t mask = 1 << 3;
@@ -837,11 +837,19 @@ qmckl_exit_code qmckl_set_jastrow_aord_vector(qmckl_context context, double cons
       return qmckl_failwith( context, rc,
                              "qmckl_set_ord_vector",
                              NULL);
-    }
+}
   }
 
   qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
   mem_info.size = (aord_num + 1) * type_nucl_num * sizeof(double);
+
+  if (size_max < mem_info.size/sizeof(double)) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_ARG_3,
+                           "qmckl_set_jastrow_aord_vector",
+                           "Array too small. Expected (aord_num+1)*type_nucl_num");
+  }
+
   double* new_array = (double*) qmckl_malloc(context, mem_info);
 
   if(new_array == NULL) {
@@ -858,7 +866,7 @@ qmckl_exit_code qmckl_set_jastrow_aord_vector(qmckl_context context, double cons
   <<post2>>
 }
 
-qmckl_exit_code qmckl_set_jastrow_bord_vector(qmckl_context context, double const * bord_vector) {
+qmckl_exit_code qmckl_set_jastrow_bord_vector(qmckl_context context, double const * bord_vector, int64_t size_max) {
 <<pre2>>
 
   int32_t mask = 1 << 4;
@@ -892,6 +900,14 @@ qmckl_exit_code qmckl_set_jastrow_bord_vector(qmckl_context context, double cons
 
   qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
   mem_info.size = (bord_num + 1) * sizeof(double);
+
+  if (size_max < mem_info.size/sizeof(double)) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_ARG_3,
+                           "qmckl_set_jastrow_bord_vector",
+                           "Array too small. Expected (bord_num+1)");
+  }
+
   double* new_array = (double*) qmckl_malloc(context, mem_info);
 
   if(new_array == NULL) {
@@ -908,7 +924,7 @@ qmckl_exit_code qmckl_set_jastrow_bord_vector(qmckl_context context, double cons
   <<post2>>
 }
 
-qmckl_exit_code qmckl_set_jastrow_cord_vector(qmckl_context context, double const * cord_vector) {
+qmckl_exit_code qmckl_set_jastrow_cord_vector(qmckl_context context, double const * cord_vector, int64_t size_max) {
 <<pre2>>
 
   int32_t mask = 1 << 5;
@@ -949,6 +965,14 @@ qmckl_exit_code qmckl_set_jastrow_cord_vector(qmckl_context context, double cons
 
   qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
   mem_info.size = dim_cord_vect * type_nucl_num * sizeof(double);
+
+  if (size_max < mem_info.size/sizeof(double)) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_ARG_3,
+                           "qmckl_set_jastrow_cord_vector",
+                           "Array too small. Expected dim_cord_vect * type_nucl_num");
+  }
+
   double* new_array = (double*) qmckl_malloc(context, mem_info);
 
   if(new_array == NULL) {
@@ -1437,6 +1461,7 @@ int64_t cord_num = n2_cord_num;
 double* aord_vector = &(n2_aord_vector[0][0]);
 double* bord_vector = &(n2_bord_vector[0]);
 double* cord_vector = &(n2_cord_vector[0][0]);
+int64_t dim_cord_vect=0;
 
 /* Initialize the Jastrow data */
 rc = qmckl_init_jastrow(context);
@@ -1449,13 +1474,13 @@ rc = qmckl_set_jastrow_type_nucl_num(context, type_nucl_num);
 assert(rc == QMCKL_SUCCESS);
 rc = qmckl_set_jastrow_type_nucl_vector(context, type_nucl_vector, nucl_num);
 assert(rc == QMCKL_SUCCESS);
-rc = qmckl_set_jastrow_aord_vector(context, aord_vector);
+rc = qmckl_set_jastrow_aord_vector(context, aord_vector,(aord_num+1)*type_nucl_num);
 assert(rc == QMCKL_SUCCESS);
-rc = qmckl_set_jastrow_bord_vector(context, bord_vector);
+rc = qmckl_set_jastrow_bord_vector(context, bord_vector,(bord_num+1));
 assert(rc == QMCKL_SUCCESS);
-rc = qmckl_set_jastrow_bord_vector(context, bord_vector);
+rc = qmckl_get_jastrow_dim_cord_vect(context, &dim_cord_vect);
 assert(rc == QMCKL_SUCCESS);
-rc = qmckl_set_jastrow_cord_vector(context, cord_vector);
+rc = qmckl_set_jastrow_cord_vector(context, cord_vector,dim_cord_vect*type_nucl_num);
 assert(rc == QMCKL_SUCCESS);
 
 /* Check if Jastrow is properly initialized */


### PR DESCRIPTION
Reorder tensor indices to conform to code review by Performance optimization team.
Following recommendations are followed:

- [ ] No branching withing loop (`if`, `select`, etc...)
- [ ] Innermost loop index should be the longest.