### PR TITLE
Fix test-build GitHub Action

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -90,7 +90,11 @@ jobs:
         make -j 4
         make install
 
-    - name: Archive test log file
+    - name: Test TREXIO
+      run: make -j 4 check
+      working-directory: trexio
+
+    - name: Archive TREXIO test log file
       if: failure()
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -91,31 +91,16 @@ jobs:
         git clone https://github.com/TREX-CoE/trexio.git
         cd trexio
         ./autogen.sh
-        mkdir _build
-        cd _build
-        ../configure --enable-silent-rules
-        make -j 4
-
-    - name: Run test
-      run: make -j 4 check
-
-    - name: Archive test log file
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-report-ubuntu
-        path: test-suite.log
-
-    - name: Dist test
-      run: make distcheck
-
-    - name: Archive test log file
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
         ./configure --prefix=${PWD}/_install --enable-silent-rules
         make -j 4
         make install
+
+    - name: Archive test log file
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-report-trexio-macos
+        path: test-suite.log
 
     - name: Build QMCkl
       run: |

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -105,7 +105,7 @@ jobs:
       run: |
         export PKG_CONFIG_PATH=${PWD}/trexio/_install/lib/pkgconfig:$PKG_CONFIG_PATH
         ./autogen.sh
-        ./configure --enable-silent-rules --enable-debug
+        ./configure CC=gcc-10 FC=gfortran-10 --enable-silent-rules --enable-debug
         make -j 4
 
     - name: Run test

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -47,6 +47,7 @@ jobs:
 
     - name: Run test
       run: make -j 4 check
+      working-directory: _build
 
     - name: Archive test log file
       if: failure()
@@ -57,13 +58,7 @@ jobs:
 
     - name: Dist test
       run: make distcheck
-
-    - name: Archive test log file
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: dist-report-ubuntu
-        path: test-suite.log
+      working-directory: _build
 
   x86_macos:
 
@@ -100,7 +95,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-report-trexio-macos
-        path: test-suite.log
+        path: trexio/test-suite.log
 
     - name: Build QMCkl
       run: |


### PR DESCRIPTION
The `test-build` cannot run on GitHub Actions due to the typo in the `.yml` file. 

Also, for out-of-source build of QMCkl `make` rules have to be executed in the build directory and not in the root.

**Note:** The MacOS CI still fails due to some recently added compiler options (e.g. see below).
```
error: unknown warning option '-Walloc-zero'; did you mean '-Walloca'? [-Werror,-Wunknown-warning-option]
```