### PR TITLE
Fix broken build

### DIFF
--- a/org/qmckl_ao.org
+++ b/org/qmckl_ao.org
@@ -2664,10 +2664,13 @@ qmckl_exit_code qmckl_finalize_basis(qmckl_context context) {
     #+end_src
 
     #+begin_src c :comments org :tangle (eval h_private_func) :exports none
+#ifdef HAVE_HPC
 qmckl_exit_code qmckl_finalize_basis_hpc (qmckl_context context);
+#endif
     #+end_src
     
     #+begin_src c :comments org :tangle (eval c) :exports none
+#ifdef HAVE_HPC
 qmckl_exit_code qmckl_finalize_basis_hpc (qmckl_context context)
 {
   qmckl_context_struct* const ctx = (qmckl_context_struct* const) context;
@@ -2729,6 +2732,7 @@ qmckl_exit_code qmckl_finalize_basis_hpc (qmckl_context context)
   }
   return QMCKL_SUCCESS;
 }
+#endif
   
     #+end_src
 


### PR DESCRIPTION
Recent HPC-related additions break the current build (`make`) process. This is because the HPC-related functions are not wrapped in the preprocessor `#ifdef HAVE_HPC` statement.