### PR TITLE
Added pane description.

### DIFF
--- a/org/hpc/qmckl_tile.org
+++ b/org/hpc/qmckl_tile.org
@@ -22,6 +22,17 @@ while also exploiting part of the sparse structure of the matrices.
              │ T_31 │ T_32 │ T_33 │
              │      │      │      │
              └──────┴──────┴──────┘
+
+  Each Tile can be further subdevided into panes. The microkernel
+  operates on individual panes.
+
+  
+   Pane
+    │        ┌───┬───┬───┐
+    │        │ 1 │ 4 │ 7 │
+    └───────►│ 2 │ 5 │ 8 │
+             │ 3 │ 6 │ 9 │
+             └───┴───┴───┘
            
   In this file, tiled matrice will be produced for the following
   types:


### PR DESCRIPTION
Prepare `qmckl_tiled_matrix` data structure for compatibility with `qmckl_dgemm`.