### PR TITLE
Fix memory leaks and add AddressSanitizer

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -76,6 +76,24 @@ jobs:
       run: make python-test
       working-directory: _build
 
+    - name: Re-build QMCkl with AddressSanitizer
+      run: |
+        mkdir _build_as
+        cd _build_as
+        ../configure CFLAGS="-g -O2 -fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address" --enable-silent-rules
+        make -j2
+
+    - name: Run test
+      run: make -j2 check
+      working-directory: _build_as
+
+    - name: Archive test log file
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-report-ubuntu-as
+        path: _build_as/test-suite.log
+
 #  x86_macos:
 #
 #    runs-on: macos-latest

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -76,6 +76,23 @@ jobs:
       run: make python-test
       working-directory: _build
 
+    - name: Re-build QMCkl with AddressSanitizer
+      run: |
+        mkdir _build_as
+        cd _build_as
+        ../configure CFLAGS="-g -O2 -fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address" --enable-silent-rules
+        make -j2
+
+    - name: Run test
+      run: make -j2 check
+      working-directory: _build_as
+
+    - name: Archive test log file
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-report-ubuntu-as
+        path: _build_as/test-suite.log
 
 #  x86_macos:
 #

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -76,23 +76,6 @@ jobs:
       run: make python-test
       working-directory: _build
 
-    - name: Re-build QMCkl with AddressSanitizer
-      run: |
-        mkdir _build_as
-        cd _build_as
-        ../configure CFLAGS="-g -O2 -fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address" --enable-silent-rules
-        make -j2
-
-    - name: Run test
-      run: make -j2 check
-      working-directory: _build_as
-
-    - name: Archive test log file
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-report-ubuntu-as
-        path: _build_as/test-suite.log
 
 #  x86_macos:
 #

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -40,7 +40,7 @@ jobs:
         ./autogen.sh
         mkdir _build
         cd _build
-        ../configure --enable-silent-rules --enable-debug
+        ../configure --enable-silent-rules
         make -j 4
         sudo make install
 
@@ -76,23 +76,23 @@ jobs:
       run: make python-test
       working-directory: _build
 
-    - name: Re-build QMCkl with AddressSanitizer
+    - name: Configure QMCkl in debug mode
       run: |
-        mkdir _build_as
-        cd _build_as
-        ../configure CFLAGS="-g -O2 -fsanitize=address -fno-omit-frame-pointer" LDFLAGS="-fsanitize=address" --enable-silent-rules
+        mkdir _build_debug
+        cd _build_debug
+        ../configure --enable-debug --enable-silent-rules
         make -j2
 
     - name: Run test
       run: make -j2 check
-      working-directory: _build_as
+      working-directory: _build_debug
 
     - name: Archive test log file
       if: failure()
       uses: actions/upload-artifact@v2
       with:
-        name: test-report-ubuntu-as
-        path: _build_as/test-suite.log
+        name: test-report-ubuntu-debug
+        path: _build_debug/test-suite.log
 
 #  x86_macos:
 #

--- a/configure.ac
+++ b/configure.ac
@@ -358,8 +358,10 @@ if test "$ok" = "yes"; then
         if test "$GCC" = "yes"; then
 	        CFLAGS="$CFLAGS \
 -g -Wall -W -Wbad-function-cast -Wcast-qual -Warray-bounds -Wdisabled-optimization \
+-fsanitize=address -fno-omit-frame-pointer \
 -Wpointer-arith -Wcast-align -Wpedantic -Wextra -Walloc-zero -Werror \
 "
+		LDFLAGS="$LDFLAGS -fsanitize=address"
         fi
         if test "$GFC" = "yes"; then
 	        FCFLAGS="$FCFLAGS \

--- a/org/qmckl_ao.org
+++ b/org/qmckl_ao.org
@@ -2423,6 +2423,7 @@ assert (rc == QMCKL_SUCCESS);
 for (int64_t i=0 ; i < nucl_num ; ++i) {
   assert(nucleus_shell_num_test[i] == nucleus_shell_num[i]);
  }
+free(nucleus_shell_num_test);
 
 shell_ang_mom_test = (int32_t*) malloc ( shell_num * sizeof(int32_t));
 rc = qmckl_get_ao_basis_shell_ang_mom (context, shell_ang_mom_test, shell_num);

--- a/org/qmckl_context.org
+++ b/org/qmckl_context.org
@@ -520,11 +520,13 @@ assert(qmckl_context_check(context) == context);
 assert(qmckl_context_destroy(context) == QMCKL_SUCCESS);
 
 /* Check that context is destroyed  */
+#ifndef DEBUG 
 assert(qmckl_context_check(context) != context);
 assert(qmckl_context_check(context) == QMCKL_NULL_CONTEXT);
 
 /* Destroy invalid context */
 assert(qmckl_context_destroy(QMCKL_NULL_CONTEXT) == QMCKL_INVALID_CONTEXT);
+#endif
     #+end_src
 
 * End of files                                                     :noexport:

--- a/org/qmckl_error.org
+++ b/org/qmckl_error.org
@@ -577,6 +577,9 @@ if (x < 0) {
   assert (strcmp(function_name,"qmckl_transpose") == 0);
   assert (strcmp(message,"Success") == 0);
 
+  exit_code = qmckl_context_destroy(context);
+  assert(exit_code == QMCKL_SUCCESS);
+
   return 0;
 }
    #+end_src

--- a/org/qmckl_jastrow.org
+++ b/org/qmckl_jastrow.org
@@ -6942,7 +6942,6 @@ assert(fabs(tmp_c[0][0][1][0][0] - 2.7083473948352403) < 1e-12);
 
 printf("%e\n%e\n", tmp_c[0][1][0][0][0],0.237440520852232);
 assert(fabs(dtmp_c[0][1][0][0][0][0] - 0.237440520852232) < 1e-12);
-return QMCKL_SUCCESS;
      #+end_src
 
 ** Electron-electron-nucleus Jastrow \(f_{een}\)
@@ -7441,7 +7440,6 @@ double factor_een[walk_num];
 rc = qmckl_get_jastrow_factor_een(context, &(factor_een[0]),walk_num);
 
 assert(fabs(factor_een[0] + 0.37407972141304213) < 1e-12);
-return QMCKL_SUCCESS;
      #+end_src
 
 ** Electron-electron-nucleus Jastrow \(f_{een}\) derivative

--- a/org/qmckl_memory.org
+++ b/org/qmckl_memory.org
@@ -173,7 +173,7 @@ void* qmckl_malloc(qmckl_context context, const qmckl_memory_info_struct info) {
 qmckl_context context = qmckl_context_create();
 
 qmckl_memory_info_struct info = qmckl_memory_info_struct_zero;
-info.size = (size_t) 3;
+info.size = (size_t) 3*sizeof(int);
 
 /* Allocate an array of ints */
 int *a = (int*) qmckl_malloc(context, info);


### PR DESCRIPTION
There is a number of memory issues revealed by the analysis performed with [Google's AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer). It detects some issues which `valgrind` does not.

- AddressSanitizer is included in the `--enable-debug` configuration of QMCkl with `GCC`
- Several detected memory leaks are fixed in the tests. Preprocessor conditional added to `test_qmckl_context`.
