### PR TITLE
Fix for compatibility with python3.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -205,7 +205,7 @@ cppcheck.out: $(qmckl_h)
 
 $(qmckl_include_i):  $(qmckl_h) $(process_header_py)
 	$(MKDIR_P) python/src
-	python $(process_header_py) $(qmckl_h)
+	python3 $(process_header_py) $(qmckl_h)
 	mv qmckl_include.i $(qmckl_include_i)
 
 


### PR DESCRIPTION
Use of fortran strings in `process_headers.py` made the compilation fail for me.
This is because the python script is called with `python python/src/process_header.py`, chaging it to `python3 python/src/process_header.py` works for me.