### PR TITLE
Fix Verificarlo CI by setting the safe.directory git variable

### DIFF
--- a/.github/workflows/vfc_test_workflow.yml
+++ b/.github/workflows/vfc_test_workflow.yml
@@ -39,7 +39,9 @@ jobs:
           make install
 
       - name: Run tests
-        run: vfc_ci test -g -r
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          vfc_ci test -g -r
 
       - name: Commit test results
         run: |


### PR DESCRIPTION
The Verificarlo CI was failing due to a change in how git detects repositories after a security vulnerability :
https://github.blog/2022-04-12-git-security-vulnerability-announced/

The simplest fix for now is probably to set the safe.directory git variable to avoid the new behaviour.