### PR TITLE
Qmckl python

### DIFF
--- a/org/qmckl_determinant.org
+++ b/org/qmckl_determinant.org
@@ -331,8 +331,8 @@ int64_t* qmckl_get_determinant_mo_index_beta (const qmckl_context context) {
 qmckl_exit_code  qmckl_set_determinant_type             (const qmckl_context context, const char t);
 qmckl_exit_code  qmckl_set_determinant_det_num_alpha    (const qmckl_context context, const int64_t det_num_alpha);
 qmckl_exit_code  qmckl_set_determinant_det_num_beta     (const qmckl_context context, const int64_t det_num_beta);
-qmckl_exit_code  qmckl_set_determinant_mo_index_alpha   (const qmckl_context context, const int64_t* mo_index_alpha);
-qmckl_exit_code  qmckl_set_determinant_mo_index_beta    (const qmckl_context context, const int64_t* mo_index_beta);
+qmckl_exit_code  qmckl_set_determinant_mo_index_alpha   (const qmckl_context context, const int64_t* mo_index_alpha, const int64_t size_max);
+qmckl_exit_code  qmckl_set_determinant_mo_index_beta    (const qmckl_context context, const int64_t* mo_index_beta, const int64_t size_max);
    #+end_src
 
    #+NAME:pre2
@@ -405,7 +405,7 @@ qmckl_exit_code qmckl_set_determinant_det_num_beta(qmckl_context context, const 
   <<post2>>
 }
 
-qmckl_exit_code  qmckl_set_determinant_mo_index_alpha(qmckl_context context, const int64_t* mo_index_alpha) {
+qmckl_exit_code  qmckl_set_determinant_mo_index_alpha(qmckl_context context, const int64_t* mo_index_alpha, const int64_t size_max) {
   <<pre2>>
 
   int32_t mask = 1 << 3;
@@ -430,6 +430,13 @@ qmckl_exit_code  qmckl_set_determinant_mo_index_alpha(qmckl_context context, con
                            NULL);
   }
 
+  if (size_max * sizeof(int64_t) < mem_info.size) {
+      return qmckl_failwith( context,
+                             QMCKL_INVALID_ARG_3,
+                             "qmckl_set_determinant_mo_index_alpha",
+                             "input array too small");
+  }
+
   memcpy(new_array, mo_index_alpha, mem_info.size);
 
   ctx->det.mo_index_alpha = new_array;
@@ -437,7 +444,7 @@ qmckl_exit_code  qmckl_set_determinant_mo_index_alpha(qmckl_context context, con
   <<post2>>
 }
 
-qmckl_exit_code  qmckl_set_determinant_mo_index_beta(qmckl_context context, const int64_t* mo_index_beta) {
+qmckl_exit_code  qmckl_set_determinant_mo_index_beta(qmckl_context context, const int64_t* mo_index_beta, const int64_t size_max) {
   <<pre2>>
 
   int32_t mask = 1 << 4;
@@ -460,6 +467,13 @@ qmckl_exit_code  qmckl_set_determinant_mo_index_beta(qmckl_context context, cons
                            QMCKL_ALLOCATION_FAILED,
                            "qmckl_set_determinant_mo_index_beta",
                            NULL);
+  }
+
+  if (size_max * sizeof(int64_t) < mem_info.size) {
+      return qmckl_failwith( context,
+                             QMCKL_INVALID_ARG_3,
+                             "qmckl_set_determinant_mo_index_beta",
+                             "input array too small");
   }
 
   memcpy(new_array, mo_index_beta, mem_info.size);

--- a/org/qmckl_determinant.org
+++ b/org/qmckl_determinant.org
@@ -1260,10 +1260,10 @@ qmckl_check(context, rc);
 rc = qmckl_set_determinant_det_num_beta (context, det_num_beta);
 qmckl_check(context, rc);
 
-rc = qmckl_set_determinant_mo_index_alpha (context, &(mo_index_alpha[0][0][0]));
+rc = qmckl_set_determinant_mo_index_alpha (context, &(mo_index_alpha[0][0][0]), det_num_alpha*chbrclf_walk_num*chbrclf_elec_up_num);
 qmckl_check(context, rc);
 
-rc = qmckl_set_determinant_mo_index_beta (context, &(mo_index_beta[0][0][0]));
+rc = qmckl_set_determinant_mo_index_beta (context, &(mo_index_beta[0][0][0]), det_num_beta*chbrclf_walk_num*chbrclf_elec_dn_num);
 qmckl_check(context, rc);
 
 // Get slater-determinant

--- a/org/qmckl_electron.org
+++ b/org/qmckl_electron.org
@@ -304,7 +304,7 @@ qmckl_set_electron_coord(qmckl_context context,
 
   if (coord == NULL) {
     return qmckl_failwith( context,
-                           QMCKL_INVALID_ARG_3,
+                           QMCKL_INVALID_ARG_4,
                            "qmckl_set_electron_coord",
                            "coord is a null pointer");
   }

--- a/org/qmckl_local_energy.org
+++ b/org/qmckl_local_energy.org
@@ -177,6 +177,42 @@ typedef struct qmckl_local_energy_struct {
    Some values are initialized by default, and are not concerned by
    this mechanism.
 
+** Access functions
+
+   When all the data for the local energy have been provided, the following
+   function returns ~true~.
+
+   #+begin_src c :comments org :tangle (eval h_func)
+bool      qmckl_local_energy_provided           (const qmckl_context context);
+   #+end_src
+
+      #+begin_src c :comments org :tangle (eval c) :noweb yes :exports none
+bool qmckl_local_energy_provided(const qmckl_context context) {
+
+  if (qmckl_context_check(context) == QMCKL_NULL_CONTEXT) {
+    return false;
+  }
+
+  qmckl_context_struct* const ctx = (qmckl_context_struct*) context;
+  assert (ctx != NULL);
+
+  qmckl_exit_code rc;
+
+  if(!qmckl_electron_provided(context)) return QMCKL_NOT_PROVIDED;
+
+  if(!qmckl_nucleus_provided(context)) return QMCKL_NOT_PROVIDED;
+
+  rc = qmckl_provide_ao_basis_ao_vgl(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  rc = qmckl_provide_mo_basis_mo_vgl(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  ctx->local_energy.provided = (ctx->local_energy.uninitialized == 0);
+  return ctx->local_energy.provided;
+}
+      #+end_src
+
 * Computation
 ** Kinetic energy
    :PROPERTIES:

--- a/org/qmckl_local_energy.org
+++ b/org/qmckl_local_energy.org
@@ -720,7 +720,7 @@ for(k = 0; k < det_num_alpha; ++k)
       mo_index_alpha[k][i][j] = j + 1;
 for(k = 0; k < det_num_beta; ++k)
   for(i = 0; i < chbrclf_walk_num; ++i)
-    for(j = 0; j < chbrclf_elec_up_num; ++j)
+    for(j = 0; j < chbrclf_elec_dn_num; ++j)
       mo_index_beta[k][i][j] = j + 1;
 
 rc = qmckl_set_determinant_type (context, typ);
@@ -732,10 +732,10 @@ assert (rc == QMCKL_SUCCESS);
 rc = qmckl_set_determinant_det_num_beta (context, det_num_beta);
 assert (rc == QMCKL_SUCCESS);
 
-rc = qmckl_set_determinant_mo_index_alpha (context, &(mo_index_alpha[0][0][0]));
+rc = qmckl_set_determinant_mo_index_alpha (context, &(mo_index_alpha[0][0][0]), det_num_alpha*chbrclf_walk_num*chbrclf_elec_up_num);
 assert (rc == QMCKL_SUCCESS);
 
-rc = qmckl_set_determinant_mo_index_beta (context, &(mo_index_beta[0][0][0]));
+rc = qmckl_set_determinant_mo_index_beta (context, &(mo_index_beta[0][0][0]),det_num_beta*chbrclf_walk_num*chbrclf_elec_dn_num);
 assert (rc == QMCKL_SUCCESS);
 
 // Get alpha determinant


### PR DESCRIPTION
Added modifications for enabling calculation of local energy via python interface.

- [x] Added `size_max` to set determinant functions
- [x] Added `local_energy_provided` check for preparing the calculation of local energy