### PR TITLE
Use encoding in open

### DIFF
--- a/tools/build_makefile.py
+++ b/tools/build_makefile.py
@@ -73,7 +73,7 @@ def main():
         TEXT[org]     = text
         HTML[org]     = html
 
-        grep = open(org, "r").read()
+        grep = open(org, "r", encoding="utf-8").read()
 
         if "(eval c)" in grep:
            C_FILES   += [c]


### PR DESCRIPTION
Python's open is locale dependent, LC_ALL=C may open it in ascii mode and fail