### PR TITLE
Fixes tab-key not working to open/close Org-mode sections in Emacs Ev…

### DIFF
--- a/tools/init.el
+++ b/tools/init.el
@@ -58,8 +58,8 @@
 (add-hook 'org-babel-after-execute-hook 'org-display-inline-images)
 '(indent-tabs-mode nil)
 
-(require 'evil)
 (setq evil-want-C-i-jump nil)
+(require 'evil)
 (evil-mode 1)
 (global-font-lock-mode t)
 (global-superword-mode 1)


### PR DESCRIPTION
…il mode.

Fix works on Linux and macOS.